### PR TITLE
fix: resolve tag prefix duplication in tag-on-merge workflow

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -37,9 +37,13 @@ jobs:
           OLD=${{ steps.get_tag.outputs.latest_tag }}
           echo "Current highest version: $OLD"
 
-          # Remove 'v' prefix and split version
-          OLD=${OLD#v}
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$OLD"
+          # Remove all leading 't' characters to fix corrupted tags like 'tt0.0.1' or 'ttt0.0.2'
+          # This handles both correct tags (t0.0.0) and corrupted ones (tt0.0.1, ttt0.0.2)
+          CLEANED_TAG=$(echo "$OLD" | sed 's/^t*//')
+          echo "Cleaned tag (removed all leading 't'): $CLEANED_TAG"
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CLEANED_TAG"
+          echo "Parsed - MAJOR: $MAJOR, MINOR: $MINOR, PATCH: $PATCH"
 
           # Increment patch version (lowest version number)
           PATCH=$((PATCH + 1))


### PR DESCRIPTION
## Summary
- Fixed tag prefix duplication bug in tag-on-merge.yml workflow
- Root cause: workflow removed 'v' prefix instead of 't', causing progressive accumulation of 't' characters
- Solution: Use `sed 's/^t*//'` to remove all leading 't' characters, handling both correct and corrupted tags

## Test plan
- [x] Identified root cause in workflow logic
- [x] Tested fix logic with various tag formats (t0.0.0, tt0.0.1, ttt0.0.2)  
- [x] Verified fix handles both correct tags and already-corrupted ones
- [ ] Will be tested when next merge to main triggers workflow

🤖 Generated with [Claude Code](https://claude.ai/code)